### PR TITLE
add google_auth on sign_up & fix page_title

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -13,6 +13,12 @@
           <div class="card-body text-center">
             <h2 class="h3 card-title text-center mt-2">ログイン</h2>
 
+            {{-- Googleでログイン --}}
+            <a href="{{ route('login.{provider}', ['provider' => 'google']) }}" 
+              class="btn btn-block btn-danger shadow-none">
+              <i class="fab fa-google mr-1"></i>Googleでログイン
+            </a>
+            
             @include('common.errors')
             
             <div class="card-text">
@@ -36,14 +42,8 @@
                   <a href="{{ route('password.request') }}" class="card-text">パスワードを忘れた方</a>
                 </div>
 
-                <button class="btn btn-block mt-3 shadow-none text-white" style="background-color: #005192" type="submit">ログイン</button>
+                <button class="btn btn-block my-3 shadow-none text-white" style="background-color: #005192" type="submit">ログイン</button>
               </form>
-
-              {{-- Googleでログイン --}}
-              <a href="{{ route('login.{provider}', ['provider' => 'google']) }}" 
-                class="btn btn-block btn-danger my-3 shadow-none">
-                <i class="fab fa-google mr-1"></i>Googleでログイン
-              </a>
 
               <div class="mt-0">
                 <a href="{{ route('register') }}" class="card-text">ユーザー登録はこちら</a>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -14,6 +14,12 @@
           <div class="card-body text-center">
             <h2 class="h3 card-title text-center mt-2">ユーザー登録</h2>
 
+            {{-- Googleで登録 --}}
+            <a href="{{ route('login.{provider}', ['provider' => 'google']) }}" 
+              class="btn btn-block btn-danger shadow-none">
+              <i class="fab fa-google mr-1"></i>Googleで登録
+            </a>
+
             @include('common.errors')
             
             <div class="card-text">

--- a/resources/views/listings/index.blade.php
+++ b/resources/views/listings/index.blade.php
@@ -1,5 +1,7 @@
 @extends('app')
 
+@section('title', 'MyTODO')
+
 @section('content')
 
 @include('nav')

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,5 +1,10 @@
 @extends('app')
 
+@section('title')
+{{ $user->name }}さん / MyTODO
+@stop
+
+
 @section('content')
 
 @include('nav')


### PR DESCRIPTION
# ユーザー登録画面の修正

## WHAT

- 『Googleで登録』のボタンを実装。動きはログインページにあるものと同様
- 各ページにページタイトルを設定。アプリ名が決まり次第、ユーザーページのものと同じ様に合わせる
